### PR TITLE
Add ref data feed name to version

### DIFF
--- a/app/controllers/ingestion/CustomsOfficeListController.scala
+++ b/app/controllers/ingestion/CustomsOfficeListController.scala
@@ -18,6 +18,7 @@ package controllers.ingestion
 
 import config.ReferenceDataControllerParserConfig
 import javax.inject.Inject
+import models.ApiDataSource.ColDataFeed
 import models._
 import play.api.Logger
 import play.api.libs.json.Json
@@ -55,7 +56,7 @@ class CustomsOfficeListController @Inject() (
         requestBody match {
           case Right(jsObject) =>
             referenceDataService
-              .insert(ReferenceDataListsPayload(jsObject))
+              .insert(ColDataFeed, ReferenceDataListsPayload(jsObject))
               .map {
                 case DataProcessingSuccessful => Accepted
                 case DataProcessingFailed =>

--- a/app/controllers/ingestion/ReferenceDataListController.scala
+++ b/app/controllers/ingestion/ReferenceDataListController.scala
@@ -18,6 +18,7 @@ package controllers.ingestion
 
 import config.ReferenceDataControllerParserConfig
 import javax.inject.Inject
+import models.ApiDataSource.RefDataFeed
 import models.CTCUP06Schema
 import models.OtherError
 import models.ReferenceDataListsPayload
@@ -58,7 +59,7 @@ class ReferenceDataListController @Inject() (
         requestBody match {
           case Right(jsObject) =>
             referenceDataService
-              .insert(ReferenceDataListsPayload(jsObject))
+              .insert(RefDataFeed, ReferenceDataListsPayload(jsObject))
               .map {
                 case DataProcessingSuccessful => Accepted
                 case DataProcessingFailed =>

--- a/app/controllers/ingestion/ReferenceDataListController.scala
+++ b/app/controllers/ingestion/ReferenceDataListController.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.ingestion
+
+import config.ReferenceDataControllerParserConfig
+import javax.inject.Inject
+import models.CTCUP06Schema
+import models.OtherError
+import models.ReferenceDataListsPayload
+import play.api.Logger
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.ControllerComponents
+import play.api.mvc.RawBuffer
+import services.ingestion.ReferenceDataService
+import services.ingestion.ReferenceDataService.DataProcessingResult.DataProcessingFailed
+import services.ingestion.ReferenceDataService.DataProcessingResult.DataProcessingSuccessful
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class ReferenceDataListController @Inject() (
+  cc: ControllerComponents,
+  referenceDataService: ReferenceDataService,
+  parseConfig: ReferenceDataControllerParserConfig,
+  cTCUP06Schema: CTCUP06Schema
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc) {
+
+  import parseConfig._
+
+  private val referenceDataListsLogger = Logger("ReferenceDataLists")
+
+  def referenceDataLists(): Action[RawBuffer] =
+    Action(referenceDataParser(parse)).async {
+
+      implicit request =>
+        val requestBody = request.body.asBytes().map(_.toArray) match {
+          case Some(body) => referenceDataService.validateAndDecompress(cTCUP06Schema, body)
+          case _          => Left(OtherError("Payload larger than memory threshold"))
+        }
+
+        requestBody match {
+          case Right(jsObject) =>
+            referenceDataService
+              .insert(ReferenceDataListsPayload(jsObject))
+              .map {
+                case DataProcessingSuccessful => Accepted
+                case DataProcessingFailed =>
+                  referenceDataListsLogger.error("Failed to save the data list because of internal error")
+                  InternalServerError(Json.toJsObject(OtherError("Failed in processing the data list")))
+              }
+          case Left(error) =>
+            referenceDataListsLogger.error(Json.toJsObject(error).toString())
+            Future.successful(BadRequest(Json.toJsObject(error)))
+        }
+    }
+}

--- a/app/models/ApiDataSource.scala
+++ b/app/models/ApiDataSource.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.Json
+import play.api.libs.json.Reads
+import play.api.libs.json.Writes
+import repositories.Query
+
+sealed trait ApiDataSource
+
+object ApiDataSource {
+  case object RefDataFeed extends ApiDataSource
+  case object ColDataFeed extends ApiDataSource
+
+  val fromString: PartialFunction[String, ApiDataSource] = {
+    case "RefDataFeed" => RefDataFeed
+    case "ColDataFeed" => ColDataFeed
+  }
+
+  implicit val jsonWrites: Writes[ApiDataSource] =
+    implicitly[Writes[String]]
+      .contramap(_.toString)
+
+  implicit val jsonReads: Reads[ApiDataSource] =
+    implicitly[Reads[String]]
+      .map(fromString.lift)
+      .map(_.get)
+
+  implicit val query: Query[ApiDataSource] =
+    Query.fromWrites(ads => Json.obj("source" -> ads))
+
+}

--- a/app/models/VersionInformation.scala
+++ b/app/models/VersionInformation.scala
@@ -23,7 +23,6 @@ import play.api.libs.json.OWrites
 import play.api.libs.json.Reads
 import play.api.libs.json.__
 import play.api.libs.functional.syntax._
-import repositories.ApiDataSource
 
 case class VersionInformation(
   messageInformation: MessageInformation,

--- a/app/models/VersionInformation.scala
+++ b/app/models/VersionInformation.scala
@@ -23,8 +23,15 @@ import play.api.libs.json.OWrites
 import play.api.libs.json.Reads
 import play.api.libs.json.__
 import play.api.libs.functional.syntax._
+import repositories.ApiDataSource
 
-case class VersionInformation(messageInformation: MessageInformation, versionId: VersionId, createdOn: LocalDateTime, listNames: Seq[ListName])
+case class VersionInformation(
+  messageInformation: MessageInformation,
+  versionId: VersionId,
+  createdOn: LocalDateTime,
+  source: ApiDataSource,
+  listNames: Seq[ListName]
+)
 
 object VersionInformation extends MongoDateTimeFormats {
 
@@ -33,6 +40,7 @@ object VersionInformation extends MongoDateTimeFormats {
       __.write[MessageInformation] and
         __.write[VersionId] and
         (__ \ "createdOn").write[LocalDateTime] and
+        (__ \ "source").write[ApiDataSource] and
         (__ \ "listNames").write[Seq[ListName]]
     )(unlift(VersionInformation.unapply))
 
@@ -41,6 +49,7 @@ object VersionInformation extends MongoDateTimeFormats {
       __.read[MessageInformation] and
         __.read[VersionId] and
         (__ \ "createdOn").read[LocalDateTime] and
+        (__ \ "source").read[ApiDataSource] and
         (__ \ "listNames").read[Seq[ListName]]
     )(VersionInformation.apply _)
 }

--- a/app/repositories/Query.scala
+++ b/app/repositories/Query.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import play.api.libs.json.JsObject
+import play.api.libs.json.OWrites
+
+trait Query[A] {
+  def toJson(a: A): JsObject
+}
+
+object Query {
+
+  def apply[A: Query]: Query[A] = implicitly[Query[A]]
+
+  def fromWrites[A: OWrites]: Query[A] = implicitly[OWrites[A]].writes _
+
+  implicit class QueryOps[A: Query](a: A) {
+    def query: JsObject = Query[A].toJson(a)
+  }
+
+}

--- a/app/repositories/VersionRepository.scala
+++ b/app/repositories/VersionRepository.scala
@@ -69,7 +69,8 @@ class VersionRepository @Inject() (versionCollection: VersionCollection, version
 
   def getLatestListNames(): Future[Seq[ListName]] = {
     case class ListNames(listNames: Seq[ListName])
-    implicit val writes = (__ \ "listNames").read[Seq[ListName]].map(ListNames(_))
+    implicit val reads: Reads[ListNames] =
+      (__ \ "listNames").read[Seq[ListName]].map(ListNames(_))
 
     def getListName(coll: JSONCollection)(source: ApiDataSource)(implicit q: Query[ApiDataSource], rds: Reads[ListName]): Future[Option[Seq[ListName]]] =
       coll
@@ -82,7 +83,7 @@ class VersionRepository @Inject() (versionCollection: VersionCollection, version
       db    <- OptionT.liftF(versionCollection())
       list1 <- OptionT(getListName(db)(RefDataFeed))
       list2 <- OptionT(getListName(db)(ColDataFeed))
-    } yield list1 ++ list2).value.map(_.get) // TODO: get rid of this get
+    } yield list1 ++ list2).value.map(_.getOrElse(Seq.empty))
   }
 
 }

--- a/app/repositories/VersionRepository.scala
+++ b/app/repositories/VersionRepository.scala
@@ -30,8 +30,9 @@ import play.api.libs.json._
 import reactivemongo.api.commands.WriteResult
 import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
 import reactivemongo.play.json.collection.JSONCollection
-import repositories.ApiDataSource.ColDataFeed
-import repositories.ApiDataSource.RefDataFeed
+import models.ApiDataSource
+import models.ApiDataSource.ColDataFeed
+import models.ApiDataSource.RefDataFeed
 import repositories.Query.QueryOps
 import services.consumption.TimeService
 
@@ -85,30 +86,5 @@ class VersionRepository @Inject() (versionCollection: VersionCollection, version
       list2 <- OptionT(getListName(db)(ColDataFeed))
     } yield list1 ++ list2).value.map(_.getOrElse(Seq.empty))
   }
-
-}
-
-sealed trait ApiDataSource
-
-object ApiDataSource {
-  case object RefDataFeed extends ApiDataSource
-  case object ColDataFeed extends ApiDataSource
-
-  val fromString: PartialFunction[String, ApiDataSource] = {
-    case "RefDataFeed" => RefDataFeed
-    case "ColDataFeed" => ColDataFeed
-  }
-
-  implicit val jsonWrites: Writes[ApiDataSource] =
-    implicitly[Writes[String]]
-      .contramap(_.toString)
-
-  implicit val jsonReads: Reads[ApiDataSource] =
-    implicitly[Reads[String]]
-      .map(fromString.lift)
-      .map(_.get)
-
-  implicit val query: Query[ApiDataSource] =
-    Query.fromWrites(ads => Json.obj("source" -> ads))
 
 }

--- a/app/repositories/VersionRepository.scala
+++ b/app/repositories/VersionRepository.scala
@@ -18,6 +18,8 @@ package repositories
 
 import java.time.LocalDateTime
 
+import cats.data._
+import cats.implicits._
 import com.google.inject.Inject
 import javax.inject.Singleton
 import models.ListName
@@ -25,9 +27,12 @@ import models.MessageInformation
 import models.VersionId
 import models.VersionInformation
 import play.api.libs.json._
-import reactivemongo.api.Cursor
 import reactivemongo.api.commands.WriteResult
 import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
+import reactivemongo.play.json.collection.JSONCollection
+import repositories.ApiDataSource.ColDataFeed
+import repositories.ApiDataSource.RefDataFeed
+import repositories.Query.QueryOps
 import services.consumption.TimeService
 
 import scala.concurrent.ExecutionContext
@@ -38,10 +43,10 @@ class VersionRepository @Inject() (versionCollection: VersionCollection, version
   ec: ExecutionContext
 ) {
 
-  def save(messageInformation: MessageInformation, listNames: Seq[ListName]): Future[VersionId] = {
+  def save(messageInformation: MessageInformation, feed: ApiDataSource, listNames: Seq[ListName]): Future[VersionId] = {
     val versionId: VersionId = versionIdProducer()
     val time: LocalDateTime  = timeService.now()
-    val versionInformation   = VersionInformation(messageInformation, versionId, time, listNames)
+    val versionInformation   = VersionInformation(messageInformation, versionId, time, feed, listNames)
 
     versionCollection().flatMap {
       _.insert(false)
@@ -62,13 +67,47 @@ class VersionRepository @Inject() (versionCollection: VersionCollection, version
         .one[VersionInformation]
     )
 
-  def getLatestListNames(): Future[Seq[ListName]] =
-    versionCollection().flatMap {
-      _.find(Json.obj(), None)
+  def getLatestListNames(): Future[Seq[ListName]] = {
+    case class ListNames(listNames: Seq[ListName])
+    implicit val writes = (__ \ "listNames").read[Seq[ListName]].map(ListNames(_))
+
+    def getListName(coll: JSONCollection)(source: ApiDataSource)(implicit q: Query[ApiDataSource], rds: Reads[ListName]): Future[Option[Seq[ListName]]] =
+      coll
+        .find(source.query, None)
         .sort(Json.obj("snapshotDate" -> -1))
-        .cursor[VersionInformation]()
-        .collect[Seq](-1, Cursor.FailOnError[Seq[VersionInformation]]())
-        .map(_.take(2).map(_.listNames).foldLeft(Seq.empty[ListName])(_ ++ _))
-    }
+        .one[ListNames]
+        .map(_.map(_.listNames))
+
+    (for {
+      db    <- OptionT.liftF(versionCollection())
+      list1 <- OptionT(getListName(db)(RefDataFeed))
+      list2 <- OptionT(getListName(db)(ColDataFeed))
+    } yield list1 ++ list2).value.map(_.get) // TODO: get rid of this get
+  }
+
+}
+
+sealed trait ApiDataSource
+
+object ApiDataSource {
+  case object RefDataFeed extends ApiDataSource
+  case object ColDataFeed extends ApiDataSource
+
+  val fromString: PartialFunction[String, ApiDataSource] = {
+    case "RefDataFeed" => RefDataFeed
+    case "ColDataFeed" => ColDataFeed
+  }
+
+  implicit val jsonWrites: Writes[ApiDataSource] =
+    implicitly[Writes[String]]
+      .contramap(_.toString)
+
+  implicit val jsonReads: Reads[ApiDataSource] =
+    implicitly[Reads[String]]
+      .map(fromString.lift)
+      .map(_.get)
+
+  implicit val query: Query[ApiDataSource] =
+    Query.fromWrites(ads => Json.obj("source" -> ads))
 
 }

--- a/app/repositories/VersionRepository.scala
+++ b/app/repositories/VersionRepository.scala
@@ -62,7 +62,7 @@ class VersionRepository @Inject() (versionCollection: VersionCollection, version
         .one[VersionInformation]
     )
 
-  def getLatest(): Future[Seq[ListName]] =
+  def getLatestListNames(): Future[Seq[ListName]] =
     versionCollection().flatMap {
       _.find(Json.obj(), None)
         .sort(Json.obj("snapshotDate" -> -1))

--- a/app/services/consumption/ListRetrievalService.scala
+++ b/app/services/consumption/ListRetrievalService.scala
@@ -39,7 +39,7 @@ class ListRetrievalService @Inject() (listRepository: ListRepository, versionRep
     }).value
 
   def getResourceLinks(): Future[Option[ResourceLinks]] =
-    versionRepository.getLatest().map {
+    versionRepository.getLatestListNames().map {
       listNames =>
         if (listNames.nonEmpty)
           Some(ResourceLinks(listNames))

--- a/app/services/ingestion/ReferenceDataService.scala
+++ b/app/services/ingestion/ReferenceDataService.scala
@@ -53,7 +53,7 @@ private[ingestion] class ReferenceDataServiceImpl @Inject() (
     extends ReferenceDataService {
 
   def insert(payload: ReferenceDataPayload): Future[DataProcessingResult] =
-    // get feed here
+    // TODO: get feed here
     versionRepository.save(payload.messageInformation, RefDataFeed, payload.listNames).flatMap {
       versionId =>
         Future

--- a/app/services/ingestion/ReferenceDataService.scala
+++ b/app/services/ingestion/ReferenceDataService.scala
@@ -23,6 +23,7 @@ import models.JsonSchemaProvider
 import models.ListName
 import models.ReferenceDataPayload
 import play.api.libs.json.JsObject
+import repositories.ApiDataSource.RefDataFeed
 import repositories.ListRepository.FailedWrite
 import repositories.ListRepository.PartialWriteFailure
 import repositories.ListRepository.SuccessfulWrite
@@ -52,7 +53,8 @@ private[ingestion] class ReferenceDataServiceImpl @Inject() (
     extends ReferenceDataService {
 
   def insert(payload: ReferenceDataPayload): Future[DataProcessingResult] =
-    versionRepository.save(payload.messageInformation, payload.listNames).flatMap {
+    // get feed here
+    versionRepository.save(payload.messageInformation, RefDataFeed, payload.listNames).flatMap {
       versionId =>
         Future
           .sequence(

--- a/app/services/ingestion/ReferenceDataService.scala
+++ b/app/services/ingestion/ReferenceDataService.scala
@@ -18,12 +18,11 @@ package services.ingestion
 
 import com.google.inject.ImplementedBy
 import com.google.inject.Inject
+import models.ApiDataSource
 import models.ErrorDetails
 import models.JsonSchemaProvider
-import models.ListName
 import models.ReferenceDataPayload
 import play.api.libs.json.JsObject
-import repositories.ApiDataSource.RefDataFeed
 import repositories.ListRepository.FailedWrite
 import repositories.ListRepository.PartialWriteFailure
 import repositories.ListRepository.SuccessfulWrite
@@ -39,7 +38,7 @@ import scala.concurrent.Future
 @ImplementedBy(classOf[ReferenceDataServiceImpl])
 trait ReferenceDataService {
 
-  def insert(payload: ReferenceDataPayload): Future[DataProcessingResult]
+  def insert(feed: ApiDataSource, payload: ReferenceDataPayload): Future[DataProcessingResult]
 
   def validateAndDecompress(jsonSchemaProvider: JsonSchemaProvider, body: Array[Byte]): Either[ErrorDetails, JsObject]
 
@@ -52,9 +51,8 @@ private[ingestion] class ReferenceDataServiceImpl @Inject() (
 )(implicit ec: ExecutionContext)
     extends ReferenceDataService {
 
-  def insert(payload: ReferenceDataPayload): Future[DataProcessingResult] =
-    // TODO: get feed here
-    versionRepository.save(payload.messageInformation, RefDataFeed, payload.listNames).flatMap {
+  def insert(feed: ApiDataSource, payload: ReferenceDataPayload): Future[DataProcessingResult] =
+    versionRepository.save(payload.messageInformation, feed, payload.listNames).flatMap {
       versionId =>
         Future
           .sequence(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,5 +3,5 @@
 GET     /customs-reference-data/lists                   controllers.consumption.ResourceLinksController.get
 GET     /customs-reference-data/lists/:listName         controllers.consumption.ListRetrievalController.get(listName: ListName)
 
-POST    /reference-data-lists                           controllers.ingestion.ReferenceDataController.referenceDataLists()
-POST    /customs-office-lists/customs-office-lists      controllers.ingestion.ReferenceDataController.customsOfficeLists
+POST    /reference-data-lists                           controllers.ingestion.ReferenceDataListController.referenceDataLists()
+POST    /customs-office-lists/customs-office-lists      controllers.ingestion.CustomsOfficeListController.customsOfficeLists()

--- a/it/repositories/VersionRepositorySpec.scala
+++ b/it/repositories/VersionRepositorySpec.scala
@@ -23,6 +23,8 @@ import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
 import reactivemongo.play.json.collection.JSONCollection
 import play.api.inject.bind
 import org.mockito.Mockito.when
+import repositories.ApiDataSource.ColDataFeed
+import repositories.ApiDataSource.RefDataFeed
 import services.consumption.TimeService
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -84,9 +86,9 @@ class VersionRepositorySpec
       when(mockVersionIdProducer.apply()).thenReturn(expectedVersionId)
       when(mockTimeService.now()).thenReturn(LocalDateTime.now())
 
-      val result = repo.save(messageInformation, Seq(listName)).futureValue
+      val result = repo.save(messageInformation, RefDataFeed, Seq(listName)).futureValue
 
-      val expectedVersionInformation = VersionInformation(messageInformation, expectedVersionId, LocalDateTime.now, Seq(listName))
+      val expectedVersionInformation = VersionInformation(messageInformation, expectedVersionId, LocalDateTime.now, RefDataFeed, Seq(listName))
 
       result mustEqual expectedVersionId
 
@@ -113,11 +115,11 @@ class VersionRepositorySpec
       val messageInformation = Arbitrary.arbitrary[MessageInformation].sample.value
       val listName           = Arbitrary.arbitrary[ListName].sample.value
 
-      repo.save(messageInformation.copy(snapshotDate = oldSnapshotDate), Seq(listName)).futureValue
-      repo.save(messageInformation.copy(snapshotDate = latestSnapshotDate), Seq(listName)).futureValue
+      repo.save(messageInformation.copy(snapshotDate = oldSnapshotDate), RefDataFeed, Seq(listName)).futureValue
+      repo.save(messageInformation.copy(snapshotDate = latestSnapshotDate), RefDataFeed, Seq(listName)).futureValue
 
       val expectedVersionInformation =
-        VersionInformation(messageInformation.copy(snapshotDate = latestSnapshotDate), VersionId("2"), latestCreatedOn, Seq(listName))
+        VersionInformation(messageInformation.copy(snapshotDate = latestSnapshotDate), VersionId("2"), latestCreatedOn, RefDataFeed, Seq(listName))
 
       val result: VersionInformation = repo.getLatest(listName).futureValue.value
 
@@ -138,10 +140,11 @@ class VersionRepositorySpec
       val listName1          = ListName("1")
       val listName2          = ListName("2")
 
-      repo.save(messageInformation.copy(snapshotDate = snapshotDate), Seq(listName1)).futureValue
-      repo.save(messageInformation.copy(snapshotDate = snapshotDate), Seq(listName2)).futureValue
+      repo.save(messageInformation.copy(snapshotDate = snapshotDate), RefDataFeed, Seq(listName1)).futureValue
+      repo.save(messageInformation.copy(snapshotDate = snapshotDate), ColDataFeed, Seq(listName2)).futureValue
 
-      val expectedVersionInformation = VersionInformation(messageInformation.copy(snapshotDate = snapshotDate), VersionId("1"), latestCreatedOn, Seq(listName1))
+      val expectedVersionInformation =
+        VersionInformation(messageInformation.copy(snapshotDate = snapshotDate), VersionId("1"), latestCreatedOn, RefDataFeed, Seq(listName1))
 
       val result: VersionInformation = repo.getLatest(listName1).futureValue.value
 
@@ -153,9 +156,9 @@ class VersionRepositorySpec
     "returns listnames for the latest REF and COL by snapshotDate" in {
       val repo = app.injector.instanceOf[VersionRepository]
 
-      val latestSnapshotDate      = LocalDate.now()
-      val latestMessageInfomation = MessageInformation("messageId", latestSnapshotDate)
-      val oldMessageInfomation    = MessageInformation("messageId", latestSnapshotDate.minusDays(1))
+      val newSnapshotDate      = LocalDate.now()
+      val newMessageInfomation = MessageInformation("messageId", newSnapshotDate)
+      val oldMessageInfomation = MessageInformation("messageId", newSnapshotDate.minusDays(1))
 
       when(mockVersionIdProducer.apply()).thenReturn(VersionId("1"), VersionId("2"), VersionId("3"))
       when(mockTimeService.now())
@@ -167,9 +170,9 @@ class VersionRepositorySpec
       val listNames2 = Seq(ListName("1"), ListName("2"))
       val listNames3 = Seq(ListName("1.1"), ListName("2.1"))
 
-      repo.save(oldMessageInfomation, listNames1).futureValue
-      repo.save(oldMessageInfomation, listNames2).futureValue
-      repo.save(latestMessageInfomation, listNames3).futureValue
+      repo.save(oldMessageInfomation, ColDataFeed, listNames1).futureValue
+      repo.save(oldMessageInfomation, RefDataFeed, listNames2).futureValue
+      repo.save(newMessageInfomation, RefDataFeed, listNames3).futureValue
 
       val result         = repo.getLatestListNames().futureValue
       val expectedResult = listNames1 ++ listNames3
@@ -181,8 +184,9 @@ class VersionRepositorySpec
   implicit val versionInformationEquality: Equality[VersionInformation] =
     (a, b) =>
       b match {
-        case VersionInformation(mi, ver, _, _) => (a.messageInformation == mi) && (a.versionId == ver)
-        case _                                 => false
+        case VersionInformation(mi, ver, _, sc, ln) =>
+          (a.messageInformation == mi) && (a.versionId == ver) && (a.source == sc) && (a.listNames == ln)
+        case _ => false
       }
 
 }

--- a/it/repositories/VersionRepositorySpec.scala
+++ b/it/repositories/VersionRepositorySpec.scala
@@ -149,30 +149,30 @@ class VersionRepositorySpec
     }
   }
 
-  "getLatest" - {
-    "returns all version with the latest snapshot date" in {
+  "getLatestListNames" - {
+    "returns listnames for the latest REF and COL by snapshotDate" in {
       val repo = app.injector.instanceOf[VersionRepository]
 
-      val latestSnapshotDate = LocalDate.now()
-      val latestCreatedOn    = LocalDateTime.now()
-
-      val oldSnapshotDate = LocalDate.now().minusDays(1)
-      val oldCreatedOn    = LocalDateTime.now().minusDays(1)
+      val latestSnapshotDate      = LocalDate.now()
+      val latestMessageInfomation = MessageInformation("messageId", latestSnapshotDate)
+      val oldMessageInfomation    = MessageInformation("messageId", latestSnapshotDate.minusDays(1))
 
       when(mockVersionIdProducer.apply()).thenReturn(VersionId("1"), VersionId("2"), VersionId("3"))
-      when(mockTimeService.now()).thenReturn(oldCreatedOn, latestCreatedOn)
+      when(mockTimeService.now())
+        .thenReturn(LocalDateTime.now().minusDays(1))
+        .thenReturn(LocalDateTime.now().minusDays(1))
+        .thenReturn(LocalDateTime.now())
 
-      val messageInformation = Arbitrary.arbitrary[MessageInformation].sample.value
-      val listNames1         = Seq(ListName("1"), ListName("2"))
-      val listNames2         = Seq(ListName("a"), ListName("b"))
-      val listNames3         = Seq(ListName("c"), ListName("d"))
+      val listNames1 = Seq(ListName("a"), ListName("b"))
+      val listNames2 = Seq(ListName("1"), ListName("2"))
+      val listNames3 = Seq(ListName("1.1"), ListName("2.1"))
 
-      repo.save(messageInformation.copy(snapshotDate = oldSnapshotDate), listNames1).futureValue
-      repo.save(messageInformation.copy(snapshotDate = latestSnapshotDate), listNames2).futureValue
-      repo.save(messageInformation.copy(snapshotDate = latestSnapshotDate), listNames3).futureValue
+      repo.save(oldMessageInfomation, listNames1).futureValue
+      repo.save(oldMessageInfomation, listNames2).futureValue
+      repo.save(latestMessageInfomation, listNames3).futureValue
 
-      val result         = repo.getLatest().futureValue
-      val expectedResult = listNames2 ++ listNames3
+      val result         = repo.getLatestListNames().futureValue
+      val expectedResult = listNames1 ++ listNames3
 
       result must contain theSameElementsAs expectedResult
     }

--- a/it/repositories/VersionRepositorySpec.scala
+++ b/it/repositories/VersionRepositorySpec.scala
@@ -23,8 +23,8 @@ import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
 import reactivemongo.play.json.collection.JSONCollection
 import play.api.inject.bind
 import org.mockito.Mockito.when
-import repositories.ApiDataSource.ColDataFeed
-import repositories.ApiDataSource.RefDataFeed
+import models.ApiDataSource.ColDataFeed
+import models.ApiDataSource.RefDataFeed
 import services.consumption.TimeService
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/it/services/InsertAndRetrieveIntegrationSpec.scala
+++ b/it/services/InsertAndRetrieveIntegrationSpec.scala
@@ -4,6 +4,8 @@ import java.time.LocalDate
 
 import base.ItSpecBase
 import generators.BaseGenerators
+import models.ApiDataSource.ColDataFeed
+import models.ApiDataSource.RefDataFeed
 import models._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
@@ -55,7 +57,7 @@ class InsertAndRetrieveIntegrationSpec
     val data               = ReferenceDataListsPayload(json)
     val expectedListNames  = (json \ "lists").as[JsObject].keys.map(ListName(_))
 
-    app.injector.instanceOf[ReferenceDataService].insert(data).futureValue
+    app.injector.instanceOf[ReferenceDataService].insert(RefDataFeed, data).futureValue
 
     val listRetrievalService = app.injector.instanceOf[ListRetrievalService]
 
@@ -79,7 +81,7 @@ class InsertAndRetrieveIntegrationSpec
     val data               = ReferenceDataListsPayload(json)
     val expectedListNames  = (json \ "lists").as[JsObject].keys.map(ListName(_))
 
-    app.injector.instanceOf[ReferenceDataService].insert(data).futureValue
+    app.injector.instanceOf[ReferenceDataService].insert(ColDataFeed, data).futureValue
 
     val listRetrievalService = app.injector.instanceOf[ListRetrievalService]
 

--- a/test/controllers/consumption/ListRetrievalControllerSpec.scala
+++ b/test/controllers/consumption/ListRetrievalControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.consumption
 
 import base.SpecBase
 import generators.ModelArbitraryInstances

--- a/test/controllers/consumption/ResourceLinksControllerSpec.scala
+++ b/test/controllers/consumption/ResourceLinksControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.consumption
 
 import base.SpecBase
 import generators.ModelArbitraryInstances

--- a/test/controllers/ingestion/CustomsOfficeListControllerSpec.scala
+++ b/test/controllers/ingestion/CustomsOfficeListControllerSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.ingestion
+
+import akka.util.ByteString
+import base.SpecBase
+import models.OtherError
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.http.Status
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsRaw
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.ingestion.ReferenceDataService
+import services.ingestion.ReferenceDataService.DataProcessingResult.DataProcessingFailed
+import services.ingestion.ReferenceDataService.DataProcessingResult.DataProcessingSuccessful
+
+import scala.concurrent.Future
+
+class CustomsOfficeListControllerSpec extends SpecBase with GuiceOneAppPerSuite with BeforeAndAfterEach {
+
+  val mockReferenceDataService = mock[ReferenceDataService]
+
+  private val testJson = Json.obj("foo" -> "bar")
+
+  "customsOfficeLists" - {
+    def fakeRequest: FakeRequest[AnyContentAsRaw] =
+      FakeRequest(POST, controllers.ingestion.routes.CustomsOfficeListController.customsOfficeLists().url)
+        .withRawBody(ByteString(testJson.toString.getBytes))
+
+    "returns ACCEPTED when the data has been decompressed, validated and processed" in {
+      when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Right(testJson))
+      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingSuccessful))
+
+      val result = route(app, fakeRequest).value
+
+      status(result) mustBe Status.ACCEPTED
+    }
+
+    "returns Bad Request when a decompression or validation error occurs" in {
+      when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Left(OtherError("error")))
+      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingSuccessful))
+
+      val result = route(app, fakeRequest).value
+
+      status(result) mustBe Status.BAD_REQUEST
+    }
+
+    "returns with an Internal Server Error when the has been validated but data was not processed successfully" in {
+      when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Right(testJson))
+      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingFailed))
+
+      val result = route(app, fakeRequest).value
+
+      status(result) mustBe Status.INTERNAL_SERVER_ERROR
+      contentAsJson(result) mustBe Json.toJsObject(OtherError("Failed in processing the data list"))
+    }
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    Mockito.reset(mockReferenceDataService)
+  }
+
+  // Do not use directly use `app` instead
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .configure("play.http.router" -> "testOnlyDoNotUseInAppConf.Routes")
+      .overrides(
+        bind[ReferenceDataService].toInstance(mockReferenceDataService)
+      )
+      .build()
+}

--- a/test/controllers/ingestion/CustomsOfficeListControllerSpec.scala
+++ b/test/controllers/ingestion/CustomsOfficeListControllerSpec.scala
@@ -51,7 +51,7 @@ class CustomsOfficeListControllerSpec extends SpecBase with GuiceOneAppPerSuite 
 
     "returns ACCEPTED when the data has been decompressed, validated and processed" in {
       when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Right(testJson))
-      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingSuccessful))
+      when(mockReferenceDataService.insert(any(), any())).thenReturn(Future.successful(DataProcessingSuccessful))
 
       val result = route(app, fakeRequest).value
 
@@ -60,7 +60,7 @@ class CustomsOfficeListControllerSpec extends SpecBase with GuiceOneAppPerSuite 
 
     "returns Bad Request when a decompression or validation error occurs" in {
       when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Left(OtherError("error")))
-      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingSuccessful))
+      when(mockReferenceDataService.insert(any(), any())).thenReturn(Future.successful(DataProcessingSuccessful))
 
       val result = route(app, fakeRequest).value
 
@@ -69,7 +69,7 @@ class CustomsOfficeListControllerSpec extends SpecBase with GuiceOneAppPerSuite 
 
     "returns with an Internal Server Error when the has been validated but data was not processed successfully" in {
       when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Right(testJson))
-      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingFailed))
+      when(mockReferenceDataService.insert(any(), any())).thenReturn(Future.successful(DataProcessingFailed))
 
       val result = route(app, fakeRequest).value
 

--- a/test/controllers/ingestion/ReferenceDataListControllerSpec.scala
+++ b/test/controllers/ingestion/ReferenceDataListControllerSpec.scala
@@ -52,7 +52,7 @@ class ReferenceDataListControllerSpec extends SpecBase with GuiceOneAppPerSuite 
 
     "returns ACCEPTED when the data has been decompressed, validated and processed" in {
       when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Right(testJson))
-      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingSuccessful))
+      when(mockReferenceDataService.insert(any(), any())).thenReturn(Future.successful(DataProcessingSuccessful))
 
       val result = route(app, fakeRequest).value
 
@@ -61,7 +61,7 @@ class ReferenceDataListControllerSpec extends SpecBase with GuiceOneAppPerSuite 
 
     "returns Bad Request when a decompression or validation error occurs" in {
       when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Left(OtherError("error")))
-      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingSuccessful))
+      when(mockReferenceDataService.insert(any(), any())).thenReturn(Future.successful(DataProcessingSuccessful))
 
       val result = route(app, fakeRequest).value
 
@@ -70,7 +70,7 @@ class ReferenceDataListControllerSpec extends SpecBase with GuiceOneAppPerSuite 
 
     "returns with an Internal Server Error when the has been validated but data was not processed successfully" in {
       when(mockReferenceDataService.validateAndDecompress(any(), any())).thenReturn(Right(testJson))
-      when(mockReferenceDataService.insert(any())).thenReturn(Future.successful(DataProcessingFailed))
+      when(mockReferenceDataService.insert(any(), any())).thenReturn(Future.successful(DataProcessingFailed))
 
       val result = route(app, fakeRequest).value
 

--- a/test/generators/ModelArbitraryInstances.scala
+++ b/test/generators/ModelArbitraryInstances.scala
@@ -24,7 +24,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 import play.api.libs.json.JsObject
-import repositories.ApiDataSource
+import models.ApiDataSource
 
 trait ModelArbitraryInstances extends JavaTimeGenerators {
 

--- a/test/generators/ModelArbitraryInstances.scala
+++ b/test/generators/ModelArbitraryInstances.scala
@@ -24,6 +24,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 import play.api.libs.json.JsObject
+import repositories.ApiDataSource
 
 trait ModelArbitraryInstances extends JavaTimeGenerators {
 
@@ -80,14 +81,18 @@ trait ModelArbitraryInstances extends JavaTimeGenerators {
   implicit val arbitraryVersionId: Arbitrary[VersionId] =
     Arbitrary(arbitrary[String].map(VersionId(_)))
 
+  implicit val arbitraryApiDataSource: Arbitrary[ApiDataSource] =
+    Arbitrary(Gen.oneOf(ApiDataSource.RefDataFeed, ApiDataSource.ColDataFeed))
+
   implicit def arbitraryVersionInformation(implicit ldt: Arbitrary[LocalDateTime]): Arbitrary[VersionInformation] =
     Arbitrary {
       for {
         mi  <- arbitrary[MessageInformation]
         v   <- arbitrary[VersionId]
         ldt <- ldt.arbitrary
+        api <- arbitrary[ApiDataSource]
         vf  <- arbitrary[ListName]
-      } yield VersionInformation(mi, v, ldt, Seq(vf))
+      } yield VersionInformation(mi, v, ldt, api, Seq(vf))
     }
 
   implicit def arbitraryReferenceDataPayload: Arbitrary[ReferenceDataPayload] =

--- a/test/services/consumption/ListRetrievalServiceSpec.scala
+++ b/test/services/consumption/ListRetrievalServiceSpec.scala
@@ -54,7 +54,7 @@ class ListRetrievalServiceSpec extends SpecBase with ModelArbitraryInstances wit
 
         running(app) {
           application =>
-            when(mockVersionRepository.getLatest()).thenReturn(listNames)
+            when(mockVersionRepository.getLatestListNames()).thenReturn(listNames)
 
             val service = application.injector.instanceOf[ListRetrievalService]
 
@@ -76,7 +76,7 @@ class ListRetrievalServiceSpec extends SpecBase with ModelArbitraryInstances wit
           application =>
             forAll(listWithMaxLength[ListName](10)) {
               listNames =>
-                when(mockVersionRepository.getLatest()).thenReturn(Future.successful(listNames))
+                when(mockVersionRepository.getLatestListNames()).thenReturn(Future.successful(listNames))
 
                 val service = application.injector.instanceOf[ListRetrievalService]
 

--- a/test/services/ingestion/ReferenceDataServiceSpec.scala
+++ b/test/services/ingestion/ReferenceDataServiceSpec.scala
@@ -18,11 +18,14 @@ package services.ingestion
 
 import base.SpecBase
 import generators.ModelGenerators.genReferenceDataListsPayload
+import models.ApiDataSource.RefDataFeed
 import models.OtherError
 import models.VersionId
+import models.ApiDataSource
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.OptionValues
 import org.scalatest.TestData
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
@@ -38,6 +41,7 @@ import repositories.ListRepository.PartialWriteFailure
 import repositories.ListRepository.SuccessfulWrite
 import services.ingestion.ReferenceDataService.DataProcessingResult.DataProcessingFailed
 import services.ingestion.ReferenceDataService.DataProcessingResult.DataProcessingSuccessful
+import generators.ModelArbitraryInstances._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -57,8 +61,8 @@ class ReferenceDataServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
 
   "insert" - {
     "reports the processing as successful if all lists are successfully saved" in {
-      forAll(genReferenceDataListsPayload(numberOfLists = 2)) {
-        payload =>
+      forAll(genReferenceDataListsPayload(numberOfLists = 2), arbitrary[ApiDataSource]) {
+        (payload, apiDataSource) =>
           val repository = mock[ListRepository]
           when(repository.insertList(any())).thenReturn(Future.successful(SuccessfulWrite))
 
@@ -70,7 +74,7 @@ class ReferenceDataServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
 
           val service = new ReferenceDataServiceImpl(repository, versionRepository, validationService)
 
-          service.insert(payload).futureValue mustBe DataProcessingSuccessful
+          service.insert(apiDataSource, payload).futureValue mustBe DataProcessingSuccessful
 
           verify(repository, times(2)).insertList(any())
           verify(versionRepository, times(1)).save(any(), any(), eqTo(payload.listNames))
@@ -78,8 +82,8 @@ class ReferenceDataServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
     }
 
     "reports the processing as failed if any lists are not saved" in {
-      forAll(genReferenceDataListsPayload(numberOfLists = 2)) {
-        payload =>
+      forAll(genReferenceDataListsPayload(numberOfLists = 2), arbitrary[ApiDataSource]) {
+        (payload, apiDataSource) =>
           val repository = mock[ListRepository]
           when(repository.insertList(any()))
             .thenReturn(Future.successful(SuccessfulWrite))
@@ -93,7 +97,7 @@ class ReferenceDataServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
 
           val service = new ReferenceDataServiceImpl(repository, versionRepository, validationService)
 
-          service.insert(payload).futureValue mustBe DataProcessingFailed
+          service.insert(apiDataSource, payload).futureValue mustBe DataProcessingFailed
 
           verify(repository, times(2)).insertList(any())
       }

--- a/test/services/ingestion/ReferenceDataServiceSpec.scala
+++ b/test/services/ingestion/ReferenceDataServiceSpec.scala
@@ -66,14 +66,14 @@ class ReferenceDataServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
           val versionRepository = mock[VersionRepository]
           val validationService = mock[SchemaValidationService]
 
-          when(versionRepository.save(any(), any())).thenReturn(Future.successful(versionId))
+          when(versionRepository.save(any(), any(), any())).thenReturn(Future.successful(versionId))
 
           val service = new ReferenceDataServiceImpl(repository, versionRepository, validationService)
 
           service.insert(payload).futureValue mustBe DataProcessingSuccessful
 
           verify(repository, times(2)).insertList(any())
-          verify(versionRepository, times(1)).save(any(), eqTo(payload.listNames))
+          verify(versionRepository, times(1)).save(any(), any(), eqTo(payload.listNames))
       }
     }
 
@@ -89,7 +89,7 @@ class ReferenceDataServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
           val versionRepository = mock[VersionRepository]
           val validationService = mock[SchemaValidationService]
 
-          when(versionRepository.save(any(), any())).thenReturn(Future.successful(versionId))
+          when(versionRepository.save(any(), any(), any())).thenReturn(Future.successful(versionId))
 
           val service = new ReferenceDataServiceImpl(repository, versionRepository, validationService)
 


### PR DESCRIPTION
This additional field on the version allows us to still allow for us to respond when there has been an update to one list but not the other.  
